### PR TITLE
Increase ec2 destroy time to 3 minutes

### DIFF
--- a/jenkins-docker/jobs/Docker-AWSCLI/config.xml
+++ b/jenkins-docker/jobs/Docker-AWSCLI/config.xml
@@ -76,7 +76,7 @@ pipeline {
                 aws --region us-east-1 ec2 create-image --instance-id ${instance_id} --name &quot;Docker-AWSCLI-CIS-`date +&quot;%Y%m%d-%H%M&quot;`&quot; --description &quot;Docker-AWSCLI AMI based off of CIS Benchmark Centos 7&quot; &gt; image_id.txt
                 aws --region us-east-1 ec2 create-tags --resources `grep ImageId image_id.txt | cut -d &apos;:&apos; -f 2 | sed &quot;s/[ ,\\\&quot;]//g&quot;` --tags &apos;Key=&quot;approval-status&quot;,Value=untested&apos;
                 cd centos-ami
-                sleep 60s
+                sleep 180s
                 terraform destroy -auto-approve -var=&quot;target-vpc=${VPC_ID}&quot; -var=&quot;target-subnet-id=${SUBNET_ID}&quot;
             &quot;&quot;&quot;
          }


### PR DESCRIPTION
AWS recommends few minutes to allow completion of AMI creation.