### PR TITLE
Updating job to generate introspection token

### DIFF
--- a/jenkins-docker/jobs/Bash_Functions/config.xml
+++ b/jenkins-docker/jobs/Bash_Functions/config.xml
@@ -374,10 +374,45 @@ EOF
 </command>
       <configuredLocalRules/>
     </hudson.tasks.Shell>
+    <hudson.tasks.Shell>
+      <command>cat &lt;&lt;&apos;EOF&apos; &gt; jwt_token.sh
+# Create JWT token
+# Clones a Git repository, generates a valid token, and exports it to an environment variable
+# Parameters:
+#   $1: Path to the secrets file
+#   $2: Git repository URL for jwt-creator
+#   $3: Token subject
+#   $4: Token duration (integer)
+#   $5: Token duration unit (default is &quot;day&quot;)
+create_jwt_token() {
+  local secret=&quot;${1}&quot;
+  local jwt_creator_repo=&quot;${2}&quot;
+  local subject=${3}
+  local duration_int=${4}
+  local duration_unit=${5:-day}
+  
+  # Clone the Git repository
+  git clone ${jwt_creator_repo} jwt_creator
+  
+  # Change to the cloned directory
+  cd jwt_creator
+  mvn clean install
+  
+  cd target
+  echo $secret &gt; secrets.txt
+  # Generate the JWT token and export it as an environment variable
+  # Currently uses the jwt generator @ https://github.com/hms-dbmi/jwt-creator 
+  # should look for something that can be better supported
+  export CREATE_JWT_TOKEN_OUTPUT=$(java -jar generateJwt.jar &quot;secrets.txt&quot; sub &quot;$subject&quot; &quot;$duration_int&quot; &quot;$duration_unit&quot; | grep -v &quot;Generating&quot;)
+  cd &quot;${WORKSPACE}&quot;
+}
+EOF</command>
+      <configuredLocalRules/>
+    </hudson.tasks.Shell>
   </builders>
   <publishers>
     <hudson.tasks.ArtifactArchiver>
-      <artifacts>target_group_attachment_functions.sh, role_functions.sh, pic_sure_rds_snapshot.sh</artifacts>
+      <artifacts>target_group_attachment_functions.sh, role_functions.sh, pic_sure_rds_snapshot.sh, jwt_token.sh</artifacts>
       <allowEmptyArchive>false</allowEmptyArchive>
       <onlyIfSuccessful>false</onlyIfSuccessful>
       <fingerprint>false</fingerprint>

--- a/jenkins-docker/jobs/Teardown and Rebuild Stage Environment/config.xml
+++ b/jenkins-docker/jobs/Teardown and Rebuild Stage Environment/config.xml
@@ -46,7 +46,7 @@
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@5.2.0">
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@5.2.1">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
@@ -139,6 +139,18 @@ for script_file in &quot;$source_scripts_folder&quot;*.sh; do
         source &quot;$script_file&quot;
     fi
 done
+
+echo &quot;pic-sure introspection token&quot; 
+# if picsure_token_introspection_token is not defined already create one
+if [ -z $picsure_token_introspection_token ]; then
+   echo &quot;No introspection given.  Generating new one.&quot;
+   create_jwt_token $picsure_client_secret &quot;$pic_sure_introspection_token_repo&quot; &quot;PSAMA_APPLICATION|$application_id_for_base_query&quot; &quot;${duration_int:-365}&quot; &quot;${duration_unit:-day}&quot;
+   picsure_token_introspection_token=&quot;${CREATE_JWT_TOKEN_OUTPUT}&quot;
+   echo &quot;introspection token generated.&quot;
+else
+  echo &quot;Using introspection token defined by global properties&quot;
+fi
+
 # Destroy and Build resources
 cd app-infrastructure
 

--- a/jenkins-docker/jobs/Update PIC-SURE Token Introspection Token/config.xml
+++ b/jenkins-docker/jobs/Update PIC-SURE Token Introspection Token/config.xml
@@ -1,10 +1,10 @@
 <?xml version='1.1' encoding='UTF-8'?>
 <project>
   <actions/>
-  <description></description>
+  <description><This job will output a valid long-term jwt token./description>
   <keepDependencies>false</keepDependencies>
   <properties/>
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@5.2.0">
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@5.2.1">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
@@ -51,47 +51,26 @@ for script_file in &quot;$source_scripts_folder&quot;*.sh; do
     fi
 done
 
-cd target
-
-reset_role
-
-aws s3 cp s3://$stack_s3_bucket/deployment_state_metadata/a/stack_variables.tf .
-
-export client_secret=`cat stack_variables.tf | grep -A3 picsure_client_secret | head -n 3 | tail -1 | cut -d &apos; &apos; -f 5 | sed &apos;s/&quot;//g&apos;`
-
-echo $client_secret &gt; secret.txt
-
-# This UUID is currently a magic number of sorts, this will need to be parameterized to make this job portable
-export new_token_introspection_token=`java -jar generateJwt.jar secret.txt sub &quot;PSAMA_APPLICATION|8b5722c9-62fd-48d6-b0bf-4f67e53efb2b&quot; 365 day | grep -v &quot;Generating&quot;`
-
-export old_token_introspection_token=`cat stack_variables.tf | grep -A3 picsure_token_introspection_token | head -n 3 | tail -1 | cut -d &apos; &apos; -f 5 | sed &apos;s/&quot;//g&apos;`
-
-sed -i &quot;s/$old_token_introspection_token/$new_token_introspection_token/g&quot; stack_variables.tf
-
-aws s3 cp stack_variables.tf s3://$stack_s3_bucket/deployment_state_metadata/a/stack_variables.tf 
-
-mv stack_variables.tf stack_variables_a.tf
-
-echo &quot;New token:&quot;
-echo &quot;${new_token_introspection_token}&quot;
-# only one stack at the moment
-#aws s3 cp s3://$stack_s3_bucket/deployment_state_metadata/b/stack_variables.tf .
-
-#export old_token_introspection_token=`cat stack_variables.tf | grep -A3 picsure_token_introspection_token | head -n 3 | tail -1 | cut -d &apos; &apos; -f 5 | sed &apos;s/&quot;//g&apos;`
-
-#sed -i &quot;s/$old_token_introspection_token/$new_token_introspection_token/g&quot; stack_variables.tf
-
-#aws s3 cp stack_variables.tf s3://$stack_s3_bucket/deployment_state_metadata/b/stack_variables.tf 
-
-#mv stack_variables.tf stack_variables_b.tf
-
-#unset AWS_ACCESS_KEY_ID
-#unset AWS_SECRET_ACCESS_KEY
-#unset AWS_SESSION_TOKEN
-</command>
+create_jwt_token $picsure_client_secret &quot;$pic_sure_introspection_token_repo&quot; &quot;PSAMA_APPLICATION|$application_id_for_base_query&quot; &quot;${duration_int:-365}&quot; &quot;${duration_unit:-day}&quot;
+if [ -n ${CREATE_JWT_TOKEN_OUTPUT} ]; then
+  echo &quot;New jwt generated update successfully.&quot;
+  echo &quot;Update the picsure_introspection_token configuration with the following:&quot;
+  echo &quot;${CREATE_JWT_TOKEN_OUTPUT}&quot;
+  echo &quot;${CREATE_JWT_TOKEN_OUTPUT}&quot; &gt; new_token
+else
+  echo &quot;Token was not generated successfully check that picsure_client_secret, pic_sure_introspection_token_repo, application_id_for_base_query configurations are a valid value.&quot;
+  exit 1
+fi</command>
       <configuredLocalRules/>
     </hudson.tasks.Shell>
   </builders>
   <publishers/>
-  <buildWrappers/>
+  <buildWrappers>
+    <hudson.plugins.ws__cleanup.PreBuildCleanup plugin="ws-cleanup@0.45">
+      <deleteDirs>false</deleteDirs>
+      <cleanupParameter></cleanupParameter>
+      <externalDelete></externalDelete>
+      <disableDeferredWipeout>false</disableDeferredWipeout>
+    </hudson.plugins.ws__cleanup.PreBuildCleanup>
+  </buildWrappers>
 </project>


### PR DESCRIPTION
# Introspection token work to get auth's token updated in the new environment
* enabling ability to create tokens automatically.  Not used currently.
* updating Introspection Token job.
* Currently a few too many manual steps for my liking.  Will work on making this configuration more dynamic to ease the monitoring and maintenance of the long-term introspection JWT