### PR TITLE
Hotfix for install jdk11

### DIFF
--- a/jenkins-docker/Dockerfile
+++ b/jenkins-docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM jenkins/jenkins:2.436-jdk11
+FROM jenkins/jenkins:2.426.1-lts-jdk11
+
 # user to swap easily between OS operations and jenkins configuration.
 ENV JENKINS_USERNAME=$USER
 
@@ -25,7 +26,7 @@ RUN echo deb http://archive.debian.org/debian stretch main >> /etc/apt/sources.l
 
 RUN apt-get update
 
-RUN apt-get -y -t stretch-backports install openjdk-11-jdk-headless
+#RUN apt-get -y -t stretch-backports install openjdk-11-jdk-headless
 
 RUN apt-get -y install apt-transport-https \
     python3-pip \

--- a/jenkins-docker/Dockerfile
+++ b/jenkins-docker/Dockerfile
@@ -25,7 +25,7 @@ RUN echo deb http://archive.debian.org/debian stretch main >> /etc/apt/sources.l
 
 RUN apt-get update
 
-RUN apt-get install -y -t stretch-backports ca-certificates-java
+RUN apt-get install -y ca-certificates-java
 
 RUN apt-get -y -t stretch-backports install openjdk-11-jdk-headless
 

--- a/jenkins-docker/Dockerfile
+++ b/jenkins-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:lts
+FROM jenkins/jenkins:2.436-jdk11
 # user to swap easily between OS operations and jenkins configuration.
 ENV JENKINS_USERNAME=$USER
 
@@ -24,8 +24,6 @@ RUN echo deb http://archive.debian.org/debian stretch-backports main >> /etc/apt
 RUN echo deb http://archive.debian.org/debian stretch main >> /etc/apt/sources.list
 
 RUN apt-get update
-
-RUN apt-get install -y ca-certificates-java
 
 RUN apt-get -y -t stretch-backports install openjdk-11-jdk-headless
 

--- a/jenkins-docker/Dockerfile
+++ b/jenkins-docker/Dockerfile
@@ -25,6 +25,8 @@ RUN echo deb http://archive.debian.org/debian stretch main >> /etc/apt/sources.l
 
 RUN apt-get update
 
+RUN apt-get install -y -t stretch-backports ca-certificates-java
+
 RUN apt-get -y -t stretch-backports install openjdk-11-jdk-headless
 
 RUN apt-get -y install apt-transport-https \


### PR DESCRIPTION
# jdk 11 is broken using archive backports 
* Just use the jenkins image that comes with jdk11
* need set jenkins home in jenkins manager after a new jenkins is created.