### PR TITLE
Stage `scriptApproval.xml` locally instead of uploading to S3

### DIFF
--- a/jenkins-docker/jobs/Create new Jenkins Server/config.xml
+++ b/jenkins-docker/jobs/Create new Jenkins Server/config.xml
@@ -62,9 +62,10 @@ openssl pkcs12 -export -in certs/jenkins.cer -inkey certs/jenkins.key -out certs
 echo &quot;# Download Jenkins config file from s3&quot;
 aws --region us-east-1 s3 cp &quot;${jenkins_config_s3_location}&quot; ./config.xml
 
-# Upload current scriptApproval.xml to S3 so the new Jenkins inherits approved scripts
-echo &quot;# Upload scriptApproval.xml to S3&quot;
-aws --region us-east-1 s3 cp &quot;${JENKINS_HOME}/scriptApproval.xml&quot; &quot;s3://${stack_s3_bucket}/jenkins_config/scriptApproval.xml&quot;
+# Bake the running Jenkins&apos; live scriptApproval.xml into the image so the
+# new server inherits all currently-approved scripts.
+echo &quot;# Stage scriptApproval.xml for the image build&quot;
+cp &quot;${JENKINS_HOME}/scriptApproval.xml&quot; ./scriptApproval.xml
 
 # Build Container
 echo &quot;# Build Container&quot;

--- a/jenkins-terraform/distro/linux/rhel9/user-scripts/script001.sh
+++ b/jenkins-terraform/distro/linux/rhel9/user-scripts/script001.sh
@@ -30,14 +30,10 @@ CONTAINER_NAME=jenkins
 
 podman rm -f $CONTAINER_NAME || true
 
-# Download scriptApproval.xml from S3 so the new Jenkins inherits approved scripts
-aws s3 cp "s3://${stack_s3_bucket}/jenkins_config/scriptApproval.xml" /var/jenkins_home/scriptApproval.xml
-
 podman run -d --privileged \
     --log-driver=journald \
     --log-opt tag=jenkins \
     -v /var/jenkins_home/workspace:/var/jenkins_home/workspace/:Z \
-    -v /var/jenkins_home/scriptApproval.xml:/var/jenkins_home/scriptApproval.xml:Z \
     -v /var/run/podman/podman.sock:/var/run/docker.sock \
     -p 443:8443 \
     --name $CONTAINER_NAME \


### PR DESCRIPTION
Stage `scriptApproval.xml` locally instead of uploading to S3 for inheriting approved Jenkins scripts. Remove redundant S3 copy in RHEL9 user script.