### PR TITLE
[ALS-11839] Convert git urls to parameters so they can be set in global parameters

### DIFF
--- a/jenkins-docker/jobs/PIC-SURE Logging Build/config.xml
+++ b/jenkins-docker/jobs/PIC-SURE Logging Build/config.xml
@@ -63,7 +63,7 @@
       <configVersion>2</configVersion>
       <userRemoteConfigs>
         <hudson.plugins.git.UserRemoteConfig>
-          <url>${git_base_url}/PIC-SURE-Logging.git</url>
+          <url>${picsure_logging_repo}</url>
         </hudson.plugins.git.UserRemoteConfig>
       </userRemoteConfigs>
       <branches>

--- a/jenkins-docker/jobs/PIC-SURE Logging Client Install/config.xml
+++ b/jenkins-docker/jobs/PIC-SURE Logging Client Install/config.xml
@@ -18,7 +18,7 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
-        <url>${git_base_url}/PIC-SURE-Logging-Client.git</url>
+        <url>${picsure_logging_client_repo}</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>


### PR DESCRIPTION
In BDC the ${git_base_url} contains /biodatacatalyst, but this is not the case in AIM-AHEAD. We cannot update AIM-AHEAD to do the same as BDC because we do have repositories in the /aim-ahead workspace in GitLab.