### PR TITLE
Jenkins monitoring jobs: Monitoring Build and Deploy + Deploy Monitoring Config

### DIFF
--- a/jenkins-docker/jobs/Deploy Monitoring Config/config.xml
+++ b/jenkins-docker/jobs/Deploy Monitoring Config/config.xml
@@ -1,0 +1,184 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description>Dashboards/config only -- no image pulls. Rebuilds config-bundle.tar.gz from
+pic-sure-all-in-one's monitoring/{prometheus,grafana,blackbox} directories and uploads it
+alone to s3://$stack_s3_bucket/monitoring/config-bundle.tar.gz, then re-invokes
+deploy-monitoring.sh on the monitoring host (tag:Node=MONITORING, tag:Environment=$environment_name)
+via SSM. deploy-monitoring.sh re-extracts the bundle and recreates the prometheus/grafana/
+blackbox containers, so dashboard and scrape-config edits roll out without touching container
+images or secrets.
+
+This job never creates or overwrites the operator-managed secrets (monitoring.env, app-token,
+db-exporters.env). See pic-sure-bdc-infrastructure docs/monitoring.md for the full S3 artifact
+contract and the manual break-glass procedure this job automates.</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>git_hash</name>
+          <defaultValue>main</defaultValue>
+          <description>pic-sure-all-in-one ref to pull monitoring/{prometheus,grafana,blackbox} from for the config bundle. Use pic_sure_api_monitoring until that branch is merged to main.</description>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>all_in_one_repo</name>
+          <defaultValue>https://github.com/hms-dbmi/pic-sure-all-in-one.git</defaultValue>
+          <description>GitHub URL for pic-sure-all-in-one. FISMA Jenkins has no global var for this repo yet, so it is passed explicitly.</description>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>public_dns</name>
+          <defaultValue></defaultValue>
+          <description>Environment's public ALB DNS name, passed through to deploy-monitoring.sh --public_dns. Empty leaves __PUBLIC_DNS__ unrendered and logs a WARN (see docs/monitoring.md).</description>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>staging_dns</name>
+          <defaultValue></defaultValue>
+          <description>Staging-stack DNS name, passed through to deploy-monitoring.sh --staging_dns. Empty leaves __STAGING_DNS__ unrendered and logs a WARN (see docs/monitoring.md).</description>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>mysql_host</name>
+          <defaultValue></defaultValue>
+          <description>RDS MySQL endpoint, passed through to deploy-monitoring.sh --mysql_host. Empty skips mysqld-exporter with a WARN (see docs/monitoring.md).</description>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <jdk>(System)</jdk>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>#!/bin/bash
+set -e
+
+# Public repo, no credentials needed (mirrors the plain `git clone` pattern in
+# Bash_Functions). FISMA Jenkins has no global var for pic-sure-all-in-one.
+rm -rf pic-sure-all-in-one
+git clone --branch &quot;${git_hash}&quot; --single-branch &quot;${all_in_one_repo}&quot; pic-sure-all-in-one</command>
+      <configuredLocalRules/>
+    </hudson.tasks.Shell>
+    <hudson.tasks.Shell>
+      <command>#!/bin/bash
+set -e
+
+# Config bundle only -- no container images, no deploy scripts re-upload.
+tar -czf config-bundle.tar.gz -C pic-sure-all-in-one/monitoring prometheus grafana blackbox
+aws s3 --sse=AES256 cp config-bundle.tar.gz &quot;s3://$stack_s3_bucket/monitoring/config-bundle.tar.gz&quot;
+
+# Secrets (monitoring.env, app-token, db-exporters.env) are OPERATOR-managed --
+# this job never writes them.</command>
+      <configuredLocalRules/>
+    </hudson.tasks.Shell>
+    <hudson.tasks.Shell>
+      <command>#!/bin/bash
+set -e
+
+source_scripts_folder=&quot;${JENKINS_HOME}/workspace/Bash_Functions/&quot;
+ls -la &quot;$source_scripts_folder&quot;
+
+for script_file in &quot;$source_scripts_folder&quot;*.sh; do
+    chmod +x &quot;$script_file&quot;
+    if [ -f &quot;$script_file&quot; ] &amp;&amp; [ -x &quot;$script_file&quot; ]; then
+        echo &quot;sourcing $script_file&quot;
+        source &quot;$script_file&quot;
+    fi
+done
+
+reset_role
+assume_role
+
+# The monitoring host is outside the blue/green stacks (no terraform.tfstate
+# output to key off), so resolve it by its Node/Environment tags instead.
+MONITORING_INSTANCE_ID=$(aws ec2 describe-instances \
+  --filters &quot;Name=tag:Node,Values=MONITORING&quot; &quot;Name=tag:Environment,Values=${environment_name}&quot; &quot;Name=instance-state-name,Values=running&quot; \
+  --query &quot;Reservations[].Instances[].InstanceId&quot; --output text)
+
+if [ -z &quot;$MONITORING_INSTANCE_ID&quot; ] || [ &quot;$(echo &quot;$MONITORING_INSTANCE_ID&quot; | wc -w)&quot; -ne 1 ]; then
+  echo &quot;ERROR: expected exactly one running instance tagged Node=MONITORING, Environment=${environment_name}. Got: '${MONITORING_INSTANCE_ID}'&quot;
+  exit 1
+fi
+
+echo &quot;Monitoring instance-id is $MONITORING_INSTANCE_ID&quot;
+
+# Re-fetch deploy-monitoring.sh (unchanged by this job, but kept current the
+# same way user-data does) and re-run it so the new bundle is extracted and
+# the prometheus/grafana/blackbox containers are recreated.
+monitoring_command_json=$(jq -n \
+  --arg s3cp &quot;aws --region us-east-1 s3 cp s3://$stack_s3_bucket/monitoring/deploy-monitoring.sh /opt/picsure/deploy-monitoring.sh&quot; \
+  --arg chmod &quot;chmod +x /opt/picsure/deploy-monitoring.sh&quot; \
+  --arg run &quot;/opt/picsure/deploy-monitoring.sh --stack_s3_bucket \&quot;$stack_s3_bucket\&quot; --environment_name \&quot;${environment_name}\&quot; --public_dns \&quot;${public_dns}\&quot; --staging_dns \&quot;${staging_dns}\&quot; --mysql_host \&quot;${mysql_host}\&quot;&quot; \
+  &apos;{commands: [$s3cp, $chmod, $run]}&apos;)
+
+monitoring_command_id=$(aws ssm send-command \
+  --instance-ids &quot;${MONITORING_INSTANCE_ID}&quot; \
+  --document-name &quot;AWS-RunShellScript&quot; \
+  --comment &quot;Deploy FISMA monitoring config bundle&quot; \
+  --parameters &quot;$monitoring_command_json&quot; \
+  --timeout-seconds 900 \
+  --query &quot;Command.CommandId&quot; \
+  --output text)
+
+# Wait for the command to complete (timeout after 60 attempts / ~5 minutes).
+monitoring_max_attempts=60
+monitoring_attempt=0
+monitoring_check_failed=false
+while true; do
+  monitoring_attempt=$((monitoring_attempt + 1))
+  if [[ ${monitoring_attempt} -gt ${monitoring_max_attempts} ]]; then
+    echo &quot;ERROR: Timed out waiting for monitoring config deploy on ${MONITORING_INSTANCE_ID} after ${monitoring_max_attempts} attempts.&quot;
+    monitoring_check_failed=true
+    break
+  fi
+  monitoring_status=$(aws ssm get-command-invocation --command-id ${monitoring_command_id} --instance-id ${MONITORING_INSTANCE_ID} --query &apos;Status&apos; --output text)
+  if [[ &quot;${monitoring_status}&quot; == &quot;Success&quot; ]]; then
+    break
+  elif [[ &quot;${monitoring_status}&quot; == &quot;Failed&quot; || &quot;${monitoring_status}&quot; == &quot;Cancelled&quot; || &quot;${monitoring_status}&quot; == &quot;TimedOut&quot; ]]; then
+    echo &quot;ERROR: Monitoring config deploy failed on ${MONITORING_INSTANCE_ID}. Command status: ${monitoring_status}&quot;
+    monitoring_check_failed=true
+    break
+  else
+    echo &quot;Waiting for monitoring config deploy... (${monitoring_status}) [attempt ${monitoring_attempt}/${monitoring_max_attempts}]&quot;
+    sleep 5
+  fi
+done
+
+echo &quot;--- deploy-monitoring.sh stdout ---&quot;
+aws ssm get-command-invocation --command-id ${monitoring_command_id} --instance-id ${MONITORING_INSTANCE_ID} --query &apos;StandardOutputContent&apos; --output text
+echo &quot;--- deploy-monitoring.sh stderr ---&quot;
+aws ssm get-command-invocation --command-id ${monitoring_command_id} --instance-id ${MONITORING_INSTANCE_ID} --query &apos;StandardErrorContent&apos; --output text
+
+reset_role
+
+if [[ &quot;$monitoring_check_failed&quot; == &quot;true&quot; ]]; then
+  exit 1
+fi</command>
+      <configuredLocalRules/>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers>
+    <hudson.plugins.ws__cleanup.PreBuildCleanup plugin="ws-cleanup@0.45">
+      <deleteDirs>false</deleteDirs>
+      <cleanupParameter></cleanupParameter>
+      <externalDelete></externalDelete>
+      <disableDeferredWipeout>false</disableDeferredWipeout>
+    </hudson.plugins.ws__cleanup.PreBuildCleanup>
+    <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@1.31">
+      <strategy class="hudson.plugins.build_timeout.impl.AbsoluteTimeOutStrategy">
+        <timeoutMinutes>20</timeoutMinutes>
+      </strategy>
+      <operationList/>
+    </hudson.plugins.build__timeout.BuildTimeoutWrapper>
+  </buildWrappers>
+</project>

--- a/jenkins-docker/jobs/Deploy Monitoring Config/config.xml
+++ b/jenkins-docker/jobs/Deploy Monitoring Config/config.xml
@@ -115,9 +115,9 @@ echo &quot;Monitoring instance-id is $MONITORING_INSTANCE_ID&quot;
 # same way user-data does) and re-run it so the new bundle is extracted and
 # the prometheus/grafana/blackbox containers are recreated.
 monitoring_command_json=$(jq -n \
-  --arg s3cp &quot;aws --region us-east-1 s3 cp s3://$stack_s3_bucket/monitoring/deploy-monitoring.sh /opt/picsure/deploy-monitoring.sh&quot; \
-  --arg chmod &quot;chmod +x /opt/picsure/deploy-monitoring.sh&quot; \
-  --arg run &quot;/opt/picsure/deploy-monitoring.sh --stack_s3_bucket \&quot;$stack_s3_bucket\&quot; --environment_name \&quot;${environment_name}\&quot; --public_dns \&quot;${public_dns}\&quot; --staging_dns \&quot;${staging_dns}\&quot; --mysql_host \&quot;${mysql_host}\&quot;&quot; \
+  --arg s3cp &quot;sudo aws --region us-east-1 s3 cp s3://$stack_s3_bucket/monitoring/deploy-monitoring.sh /opt/picsure/deploy-monitoring.sh&quot; \
+  --arg chmod &quot;sudo chmod +x /opt/picsure/deploy-monitoring.sh&quot; \
+  --arg run &quot;sudo /opt/picsure/deploy-monitoring.sh --stack_s3_bucket \&quot;$stack_s3_bucket\&quot; --environment_name \&quot;${environment_name}\&quot; --public_dns \&quot;${public_dns}\&quot; --staging_dns \&quot;${staging_dns}\&quot; --mysql_host \&quot;${mysql_host}\&quot;&quot; \
   &apos;{commands: [$s3cp, $chmod, $run]}&apos;)
 
 monitoring_command_id=$(aws ssm send-command \
@@ -129,8 +129,8 @@ monitoring_command_id=$(aws ssm send-command \
   --query &quot;Command.CommandId&quot; \
   --output text)
 
-# Wait for the command to complete (timeout after 60 attempts / ~5 minutes).
-monitoring_max_attempts=60
+# Wait for the command to complete (timeout after 190 attempts / ~16 minutes).
+monitoring_max_attempts=190
 monitoring_attempt=0
 monitoring_check_failed=false
 while true; do

--- a/jenkins-docker/jobs/Monitoring Build and Deploy/config.xml
+++ b/jenkins-docker/jobs/Monitoring Build and Deploy/config.xml
@@ -96,7 +96,7 @@ git clone --branch &quot;${git_hash}&quot; --single-branch &quot;${all_in_one_re
     </hudson.tasks.Shell>
     <hudson.tasks.Shell>
       <command>#!/bin/bash
-set -e
+set -euo pipefail
 
 # Pinned image set (7) per docs/monitoring.md. podman-exporter is renamed on
 # upload -- deploy-monitoring.sh/deploy-exporters.sh expect the exact key
@@ -175,9 +175,9 @@ echo &quot;Monitoring instance-id is $MONITORING_INSTANCE_ID&quot;
 # Re-fetch the freshly-uploaded deploy-monitoring.sh the same way user-data does,
 # then re-run it, so redeploys pick up script changes as well as artifact changes.
 monitoring_command_json=$(jq -n \
-  --arg s3cp &quot;aws --region us-east-1 s3 cp s3://$stack_s3_bucket/monitoring/deploy-monitoring.sh /opt/picsure/deploy-monitoring.sh&quot; \
-  --arg chmod &quot;chmod +x /opt/picsure/deploy-monitoring.sh&quot; \
-  --arg run &quot;/opt/picsure/deploy-monitoring.sh --stack_s3_bucket \&quot;$stack_s3_bucket\&quot; --environment_name \&quot;${environment_name}\&quot; --public_dns \&quot;${public_dns}\&quot; --staging_dns \&quot;${staging_dns}\&quot; --mysql_host \&quot;${mysql_host}\&quot;&quot; \
+  --arg s3cp &quot;sudo aws --region us-east-1 s3 cp s3://$stack_s3_bucket/monitoring/deploy-monitoring.sh /opt/picsure/deploy-monitoring.sh&quot; \
+  --arg chmod &quot;sudo chmod +x /opt/picsure/deploy-monitoring.sh&quot; \
+  --arg run &quot;sudo /opt/picsure/deploy-monitoring.sh --stack_s3_bucket \&quot;$stack_s3_bucket\&quot; --environment_name \&quot;${environment_name}\&quot; --public_dns \&quot;${public_dns}\&quot; --staging_dns \&quot;${staging_dns}\&quot; --mysql_host \&quot;${mysql_host}\&quot;&quot; \
   &apos;{commands: [$s3cp, $chmod, $run]}&apos;)
 
 monitoring_command_id=$(aws ssm send-command \
@@ -189,8 +189,8 @@ monitoring_command_id=$(aws ssm send-command \
   --query &quot;Command.CommandId&quot; \
   --output text)
 
-# Wait for the command to complete (timeout after 60 attempts / ~5 minutes).
-monitoring_max_attempts=60
+# Wait for the command to complete (timeout after 190 attempts / ~16 minutes).
+monitoring_max_attempts=190
 monitoring_attempt=0
 monitoring_check_failed=false
 while true; do

--- a/jenkins-docker/jobs/Monitoring Build and Deploy/config.xml
+++ b/jenkins-docker/jobs/Monitoring Build and Deploy/config.xml
@@ -1,0 +1,244 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description>Builds and publishes the FISMA monitoring stack deploy artifacts (the 7 pinned
+container images, config-bundle.tar.gz, deploy-monitoring.sh, deploy-exporters.sh) to
+s3://$stack_s3_bucket/monitoring/, then re-invokes deploy-monitoring.sh on the monitoring
+host (tag:Node=MONITORING, tag:Environment=$environment_name) via SSM so the new artifacts
+are picked up immediately.
+
+This job never creates or overwrites the operator-managed secrets (monitoring.env, app-token,
+db-exporters.env) under s3://$stack_s3_bucket/monitoring/ -- those are hand-authored per
+environment and must already exist in S3 before the first deploy.
+
+See pic-sure-bdc-infrastructure docs/monitoring.md for the full S3 artifact contract, the
+manual break-glass procedure this job automates, and the deploy-monitoring.sh WARN/skip
+behavior when --public_dns/--staging_dns/--mysql_host are left empty.</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>git_hash</name>
+          <defaultValue>main</defaultValue>
+          <description>pic-sure-all-in-one ref to pull monitoring/{prometheus,grafana,blackbox} from for the config bundle. Use pic_sure_api_monitoring until that branch is merged to main.</description>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>infra_git_hash</name>
+          <defaultValue>main</defaultValue>
+          <description>pic-sure-bdc-infrastructure ref to pull app-infrastructure/scripts/deploy/deploy-{monitoring,exporters}.sh from.</description>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>all_in_one_repo</name>
+          <defaultValue>https://github.com/hms-dbmi/pic-sure-all-in-one.git</defaultValue>
+          <description>GitHub URL for pic-sure-all-in-one. FISMA Jenkins has no global var for this repo yet, so it is passed explicitly.</description>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>public_dns</name>
+          <defaultValue></defaultValue>
+          <description>Environment's public ALB DNS name, passed through to deploy-monitoring.sh --public_dns. Empty leaves __PUBLIC_DNS__ unrendered and logs a WARN (see docs/monitoring.md).</description>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>staging_dns</name>
+          <defaultValue></defaultValue>
+          <description>Staging-stack DNS name, passed through to deploy-monitoring.sh --staging_dns. Empty leaves __STAGING_DNS__ unrendered and logs a WARN (see docs/monitoring.md).</description>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>mysql_host</name>
+          <defaultValue></defaultValue>
+          <description>RDS MySQL endpoint, passed through to deploy-monitoring.sh --mysql_host. Empty skips mysqld-exporter with a WARN (see docs/monitoring.md).</description>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@5.2.0">
+    <configVersion>2</configVersion>
+    <userRemoteConfigs>
+      <hudson.plugins.git.UserRemoteConfig>
+        <url>${infrastructure_git_repo}</url>
+        <credentialsId>${git_credentials_id}</credentialsId>
+      </hudson.plugins.git.UserRemoteConfig>
+    </userRemoteConfigs>
+    <branches>
+      <hudson.plugins.git.BranchSpec>
+        <name>${infra_git_hash}</name>
+      </hudson.plugins.git.BranchSpec>
+    </branches>
+    <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+    <submoduleCfg class="empty-list"/>
+    <extensions/>
+  </scm>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <jdk>(System)</jdk>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>#!/bin/bash
+set -e
+
+# pic-sure-bdc-infrastructure is checked out by the job SCM into $WORKSPACE root
+# (app-infrastructure/scripts/deploy/*). Clone pic-sure-all-in-one separately --
+# FISMA Jenkins has no global var for it, and it is public so no credentials are
+# needed (mirrors the plain `git clone` pattern in Bash_Functions).
+rm -rf pic-sure-all-in-one
+git clone --branch &quot;${git_hash}&quot; --single-branch &quot;${all_in_one_repo}&quot; pic-sure-all-in-one</command>
+      <configuredLocalRules/>
+    </hudson.tasks.Shell>
+    <hudson.tasks.Shell>
+      <command>#!/bin/bash
+set -e
+
+# Pinned image set (7) per docs/monitoring.md. podman-exporter is renamed on
+# upload -- deploy-monitoring.sh/deploy-exporters.sh expect the exact key
+# containers/podman-exporter.tar.gz regardless of the upstream image name.
+images=(
+  &quot;prom/prometheus:v3.4.1|prometheus&quot;
+  &quot;grafana/grafana:11.6.0|grafana&quot;
+  &quot;prom/node-exporter:v1.9.1|node-exporter&quot;
+  &quot;quay.io/navidys/prometheus-podman-exporter:v1.17.0|podman-exporter&quot;
+  &quot;lusotycoon/apache-exporter:v1.0.10|apache-exporter&quot;
+  &quot;prom/blackbox-exporter:v0.26.0|blackbox-exporter&quot;
+  &quot;prom/mysqld-exporter:v0.17.2|mysqld-exporter&quot;
+)
+
+mkdir -p docker_image_output
+cd docker_image_output
+
+for entry in &quot;${images[@]}&quot;; do
+  image=&quot;${entry%%|*}&quot;
+  name=&quot;${entry##*|}&quot;
+  echo &quot;Pulling ${image} -&gt; ${name}.tar.gz&quot;
+  docker pull &quot;${image}&quot;
+  docker save &quot;${image}&quot; | gzip &gt; &quot;${name}.tar.gz&quot;
+  aws s3 --sse=AES256 cp &quot;${name}.tar.gz&quot; &quot;s3://$stack_s3_bucket/monitoring/containers/${name}.tar.gz&quot;
+done</command>
+      <configuredLocalRules/>
+    </hudson.tasks.Shell>
+    <hudson.tasks.Shell>
+      <command>#!/bin/bash
+set -e
+
+# Config bundle: prometheus/ + grafana/ + blackbox/ trees from pic-sure-all-in-one's
+# monitoring/ directory (blackbox/ added by M5).
+tar -czf config-bundle.tar.gz -C pic-sure-all-in-one/monitoring prometheus grafana blackbox
+aws s3 --sse=AES256 cp config-bundle.tar.gz &quot;s3://$stack_s3_bucket/monitoring/config-bundle.tar.gz&quot;
+
+# Deploy scripts (source: app-infrastructure/scripts/deploy/ in this checkout).
+aws s3 --sse=AES256 cp app-infrastructure/scripts/deploy/deploy-monitoring.sh &quot;s3://$stack_s3_bucket/monitoring/deploy-monitoring.sh&quot;
+aws s3 --sse=AES256 cp app-infrastructure/scripts/deploy/deploy-exporters.sh &quot;s3://$stack_s3_bucket/monitoring/deploy-exporters.sh&quot;
+
+# Secrets (monitoring.env, app-token, db-exporters.env) are OPERATOR-managed --
+# this job never writes them.</command>
+      <configuredLocalRules/>
+    </hudson.tasks.Shell>
+    <hudson.tasks.Shell>
+      <command>#!/bin/bash
+set -e
+
+source_scripts_folder=&quot;${JENKINS_HOME}/workspace/Bash_Functions/&quot;
+ls -la &quot;$source_scripts_folder&quot;
+
+for script_file in &quot;$source_scripts_folder&quot;*.sh; do
+    chmod +x &quot;$script_file&quot;
+    if [ -f &quot;$script_file&quot; ] &amp;&amp; [ -x &quot;$script_file&quot; ]; then
+        echo &quot;sourcing $script_file&quot;
+        source &quot;$script_file&quot;
+    fi
+done
+
+reset_role
+assume_role
+
+# The monitoring host is outside the blue/green stacks (no terraform.tfstate
+# output to key off), so resolve it by its Node/Environment tags instead.
+MONITORING_INSTANCE_ID=$(aws ec2 describe-instances \
+  --filters &quot;Name=tag:Node,Values=MONITORING&quot; &quot;Name=tag:Environment,Values=${environment_name}&quot; &quot;Name=instance-state-name,Values=running&quot; \
+  --query &quot;Reservations[].Instances[].InstanceId&quot; --output text)
+
+if [ -z &quot;$MONITORING_INSTANCE_ID&quot; ] || [ &quot;$(echo &quot;$MONITORING_INSTANCE_ID&quot; | wc -w)&quot; -ne 1 ]; then
+  echo &quot;ERROR: expected exactly one running instance tagged Node=MONITORING, Environment=${environment_name}. Got: '${MONITORING_INSTANCE_ID}'&quot;
+  exit 1
+fi
+
+echo &quot;Monitoring instance-id is $MONITORING_INSTANCE_ID&quot;
+
+# Re-fetch the freshly-uploaded deploy-monitoring.sh the same way user-data does,
+# then re-run it, so redeploys pick up script changes as well as artifact changes.
+monitoring_command_json=$(jq -n \
+  --arg s3cp &quot;aws --region us-east-1 s3 cp s3://$stack_s3_bucket/monitoring/deploy-monitoring.sh /opt/picsure/deploy-monitoring.sh&quot; \
+  --arg chmod &quot;chmod +x /opt/picsure/deploy-monitoring.sh&quot; \
+  --arg run &quot;/opt/picsure/deploy-monitoring.sh --stack_s3_bucket \&quot;$stack_s3_bucket\&quot; --environment_name \&quot;${environment_name}\&quot; --public_dns \&quot;${public_dns}\&quot; --staging_dns \&quot;${staging_dns}\&quot; --mysql_host \&quot;${mysql_host}\&quot;&quot; \
+  &apos;{commands: [$s3cp, $chmod, $run]}&apos;)
+
+monitoring_command_id=$(aws ssm send-command \
+  --instance-ids &quot;${MONITORING_INSTANCE_ID}&quot; \
+  --document-name &quot;AWS-RunShellScript&quot; \
+  --comment &quot;Deploy FISMA monitoring stack&quot; \
+  --parameters &quot;$monitoring_command_json&quot; \
+  --timeout-seconds 900 \
+  --query &quot;Command.CommandId&quot; \
+  --output text)
+
+# Wait for the command to complete (timeout after 60 attempts / ~5 minutes).
+monitoring_max_attempts=60
+monitoring_attempt=0
+monitoring_check_failed=false
+while true; do
+  monitoring_attempt=$((monitoring_attempt + 1))
+  if [[ ${monitoring_attempt} -gt ${monitoring_max_attempts} ]]; then
+    echo &quot;ERROR: Timed out waiting for monitoring deploy on ${MONITORING_INSTANCE_ID} after ${monitoring_max_attempts} attempts.&quot;
+    monitoring_check_failed=true
+    break
+  fi
+  monitoring_status=$(aws ssm get-command-invocation --command-id ${monitoring_command_id} --instance-id ${MONITORING_INSTANCE_ID} --query &apos;Status&apos; --output text)
+  if [[ &quot;${monitoring_status}&quot; == &quot;Success&quot; ]]; then
+    break
+  elif [[ &quot;${monitoring_status}&quot; == &quot;Failed&quot; || &quot;${monitoring_status}&quot; == &quot;Cancelled&quot; || &quot;${monitoring_status}&quot; == &quot;TimedOut&quot; ]]; then
+    echo &quot;ERROR: Monitoring deploy failed on ${MONITORING_INSTANCE_ID}. Command status: ${monitoring_status}&quot;
+    monitoring_check_failed=true
+    break
+  else
+    echo &quot;Waiting for monitoring deploy... (${monitoring_status}) [attempt ${monitoring_attempt}/${monitoring_max_attempts}]&quot;
+    sleep 5
+  fi
+done
+
+echo &quot;--- deploy-monitoring.sh stdout ---&quot;
+aws ssm get-command-invocation --command-id ${monitoring_command_id} --instance-id ${MONITORING_INSTANCE_ID} --query &apos;StandardOutputContent&apos; --output text
+echo &quot;--- deploy-monitoring.sh stderr ---&quot;
+aws ssm get-command-invocation --command-id ${monitoring_command_id} --instance-id ${MONITORING_INSTANCE_ID} --query &apos;StandardErrorContent&apos; --output text
+
+reset_role
+
+if [[ &quot;$monitoring_check_failed&quot; == &quot;true&quot; ]]; then
+  exit 1
+fi</command>
+      <configuredLocalRules/>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers>
+    <hudson.plugins.ws__cleanup.PreBuildCleanup plugin="ws-cleanup@0.45">
+      <deleteDirs>false</deleteDirs>
+      <cleanupParameter></cleanupParameter>
+      <externalDelete></externalDelete>
+      <disableDeferredWipeout>false</disableDeferredWipeout>
+    </hudson.plugins.ws__cleanup.PreBuildCleanup>
+    <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@1.31">
+      <strategy class="hudson.plugins.build_timeout.impl.AbsoluteTimeOutStrategy">
+        <timeoutMinutes>60</timeoutMinutes>
+      </strategy>
+      <operationList/>
+    </hudson.plugins.build__timeout.BuildTimeoutWrapper>
+  </buildWrappers>
+</project>


### PR DESCRIPTION
Adds the CI automation for the PIC-SURE monitoring stack. Companion PRs: hms-dbmi/pic-sure-bdc-infrastructure#213 (infrastructure + deploy scripts + runbook) and hms-dbmi/pic-sure-all-in-one#254 (config assets the bundle packages).

## Jobs
- **Monitoring Build and Deploy** — pulls the 7 pinned monitoring images (`set -euo pipefail` guards the save/gzip pipeline), uploads them plus the config bundle (from pic-sure-all-in-one `monitoring/`) and the deploy scripts (from pic-sure-bdc-infrastructure) to `s3://$stack_s3_bucket/monitoring/`, then triggers `deploy-monitoring.sh` on the monitoring host via SSM (instance resolved by `Node=MONITORING` + `Environment` tags with an exactly-one-match guard; poll window sized past the 900s command timeout)
- **Deploy Monitoring Config** — bundle-only variant for dashboard/scrape-config rollouts, no image pulls

## Notes for review
- Uses only plugin classes and global vars already present in sibling jobs (`infrastructure_git_repo`, `git_credentials_id`, `stack_s3_bucket`, `environment_name`, `app_acct_id`, `jenkins_provisioning_assume_role_name`); pic-sure-all-in-one has no global var, so its URL is a string parameter
- `git_hash` defaults to `main` — use `pic_sure_api_monitoring` until the companion PRs merge
- Jobs never create or overwrite the operator-managed secrets (`monitoring.env`, `app-token`, `db-exporters.env`)
- SSM payload commands use defensive `sudo` per existing conventions; first run should confirm payload execution context matches expectations